### PR TITLE
Improve payslip maker

### DIFF
--- a/payslip.html
+++ b/payslip.html
@@ -146,6 +146,10 @@
           PAYE (R)
           <input type="number" id="paye" min="0" step="0.01">
         </label>
+        <label class="switch">
+          <input type="checkbox" id="autoPaye" checked>
+          <span class="switch-label">Auto calculate PAYE</span>
+        </label>
         <label>
           UIF (R)
           <input type="number" id="uif" min="0" step="0.01">


### PR DESCRIPTION
## Summary
- add option to auto-calc PAYE using 2024/25 brackets
- include toggle in payslip page
- fix PAYE calculations to use incremental bracket logic

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6841b71727f4832eb2e946c56dd6e9b2